### PR TITLE
Add about page with artist bio

### DIFF
--- a/.react-router/types/app/routes/+types/about.ts
+++ b/.react-router/types/app/routes/+types/about.ts
@@ -1,0 +1,40 @@
+// React Router generated types for route:
+// routes/about.tsx
+
+import type * as T from "react-router/route-module"
+
+import type { Info as Parent0 } from "../../+types/root.js"
+
+type Module = typeof import("../about.js")
+
+export type Info = {
+  parents: [Parent0],
+  id: "routes/about"
+  file: "routes/about.tsx"
+  path: "about"
+  params: {} & { [key: string]: string | undefined }
+  module: Module
+  loaderData: T.CreateLoaderData<Module>
+  actionData: T.CreateActionData<Module>
+}
+
+export namespace Route {
+  export type LinkDescriptors = T.LinkDescriptors
+  export type LinksFunction = () => LinkDescriptors
+
+  export type MetaArgs = T.CreateMetaArgs<Info>
+  export type MetaDescriptors = T.MetaDescriptors
+  export type MetaFunction = (args: MetaArgs) => MetaDescriptors
+
+  export type HeadersArgs = T.HeadersArgs
+  export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit
+
+  export type LoaderArgs = T.CreateServerLoaderArgs<Info>
+  export type ClientLoaderArgs = T.CreateClientLoaderArgs<Info>
+  export type ActionArgs = T.CreateServerActionArgs<Info>
+  export type ClientActionArgs = T.CreateClientActionArgs<Info>
+
+  export type HydrateFallbackProps = T.CreateHydrateFallbackProps<Info>
+  export type ComponentProps = T.CreateComponentProps<Info>
+  export type ErrorBoundaryProps = T.CreateErrorBoundaryProps<Info>
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,6 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/home.tsx"),
+  route("about", "routes/about.tsx"),
+] satisfies RouteConfig;

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,0 +1,56 @@
+import type { Route } from "./+types/about";
+import { Link } from "react-router";
+
+const bioParagraphs = [
+  "Mike Holm never set out to be a chameleon, but music kept reshaping him. He first found his voice behind a microphone, chasing hooks and harmonies as a singer before rhythm took over and he moved behind the drum kit. That shift unlocked a new obsession with groove, dynamic, and feel, grounding his songwriting in pulse as much as melody.",
+  "Today, he writes like a multi-genre cartographer, sketching bridges between indie rock energy, soulful pop flourishes, and cinematic textures. The drummer in him keeps every chorus honest, while the vocalist in him still chases lines that stick. It’s a toolkit built from miles on the road, late-night studio experiments, and a curiosity that refuses to stay in one lane.",
+  "Armed with guitars, synths, drums, and whatever else a song needs, Mike now produces from the inside out—crafting arrangements that balance grit and gloss, storytelling and motion. It’s the sound of a singer-turned-drummer-turned-multi-instrumentalist who learned that the most interesting destinations come from following the detours.",
+];
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "About | MIKE HOLM MUSIC" },
+    {
+      name: "description",
+      content:
+        "Meet Mike Holm: singer-turned-drummer-turned multi-genre songwriter and multi-instrumentalist crafting rhythmic, melodic stories.",
+    },
+  ];
+}
+
+export default function About() {
+  return (
+    <main className="min-h-screen pt-12 pb-16 px-4 flex justify-center">
+      <div className="max-w-3xl w-full flex flex-col gap-8">
+        <header className="flex flex-col gap-4">
+          <p className="text-sm uppercase tracking-[0.2em] text-gray-400">About</p>
+          <h1 className="text-4xl md:text-5xl font-semibold">Mike Holm</h1>
+          <p className="text-lg text-gray-200">
+            Singer turned drummer turned multi-genre songwriter and multi-instrumentalist.
+          </p>
+          <div className="flex gap-3 flex-wrap">
+            <Link
+              to="/"
+              className="rounded-full border border-white/20 px-4 py-2 text-sm hover:border-white hover:bg-white/5 transition"
+            >
+              Home
+            </Link>
+            <a
+              href="https://linktr.ee/sandcastles"
+              className="rounded-full border border-white/20 px-4 py-2 text-sm hover:border-white hover:bg-white/5 transition"
+              rel="noreferrer"
+            >
+              Listen
+            </a>
+          </div>
+        </header>
+
+        <section className="flex flex-col gap-6 text-lg leading-relaxed text-gray-100">
+          {bioParagraphs.map((paragraph) => (
+            <p key={paragraph.slice(0, 20)}>{paragraph}</p>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -24,10 +24,7 @@ export default function About() {
       <div className="max-w-3xl w-full flex flex-col gap-8">
         <header className="flex flex-col gap-4">
           <p className="text-sm uppercase tracking-[0.2em] text-gray-400">About</p>
-          <h1 className="text-4xl md:text-5xl font-semibold">Mike Holm</h1>
-          <p className="text-lg text-gray-200">
-            Singer turned drummer turned multi-genre songwriter and multi-instrumentalist.
-          </p>
+          <h1 className="md:text-8xl text-6xl font-thin">Mike Holm</h1>
           <div className="flex gap-3 flex-wrap">
             <Link
               to="/"
@@ -35,13 +32,6 @@ export default function About() {
             >
               Home
             </Link>
-            <a
-              href="https://linktr.ee/sandcastles"
-              className="rounded-full border border-white/20 px-4 py-2 text-sm hover:border-white hover:bg-white/5 transition"
-              rel="noreferrer"
-            >
-              Listen
-            </a>
           </div>
         </header>
 

--- a/app/welcome/welcome.tsx
+++ b/app/welcome/welcome.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router";
+
 export function Welcome() {
   const [head, ...rest] = promo;
   return (
@@ -5,6 +7,14 @@ export function Welcome() {
       <div className="flex-1 flex flex-col items-center gap-4 md:gap-8 min-h-0 max-w-xl px-4">
         <header className="flex flex-1 flex-col items-start gap-5 md:gap-9">
           <h1 className="md:text-8xl text-6xl font-thin">Mike Holm</h1>
+          <div className="flex gap-3">
+            <Link
+              to="/about"
+              className="rounded-full border border-white/30 px-4 py-2 text-sm font-medium hover:border-white hover:bg-white/10 transition"
+            >
+              About
+            </Link>
+          </div>
           <ul className="flex gap-4 items-center">
             {socials.map(({ href, label, logo: Logo }) => (
               <li key={href}>


### PR DESCRIPTION
## Summary
- add an About page with a biography for Mike Holm
- link the homepage to the new About page for quick navigation

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947679409d8832e8e27844b23f78147)