### PR TITLE
Add shows page powered by Google Calendar

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,29 @@
+name: Cypress E2E
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          install: false
+          start: npm run dev -- --host --port 5173
+          wait-on: http://localhost:5173
+          command: npx cypress@13.15.2 run --e2e --browser chrome

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -24,6 +24,6 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           install: false
-          start: npm run dev -- --host --port 5173
+          start: CALENDAR_URL=http://localhost:5173/test-calendar.ics npm run dev -- --host --port 5173
           wait-on: http://localhost:5173
           command: npx cypress@13.15.2 run --e2e --browser chrome

--- a/.react-router/types/app/routes/+types/shows.ts
+++ b/.react-router/types/app/routes/+types/shows.ts
@@ -1,0 +1,40 @@
+// React Router generated types for route:
+// routes/shows.tsx
+
+import type * as T from "react-router/route-module"
+
+import type { Info as Parent0 } from "../../+types/root.js"
+
+type Module = typeof import("../shows.js")
+
+export type Info = {
+  parents: [Parent0],
+  id: "routes/shows"
+  file: "routes/shows.tsx"
+  path: "/shows"
+  params: {} & { [key: string]: string | undefined }
+  module: Module
+  loaderData: T.CreateLoaderData<Module>
+  actionData: T.CreateActionData<Module>
+}
+
+export namespace Route {
+  export type LinkDescriptors = T.LinkDescriptors
+  export type LinksFunction = () => LinkDescriptors
+
+  export type MetaArgs = T.CreateMetaArgs<Info>
+  export type MetaDescriptors = T.MetaDescriptors
+  export type MetaFunction = (args: MetaArgs) => MetaDescriptors
+
+  export type HeadersArgs = T.HeadersArgs
+  export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit
+
+  export type LoaderArgs = T.CreateServerLoaderArgs<Info>
+  export type ClientLoaderArgs = T.CreateClientLoaderArgs<Info>
+  export type ActionArgs = T.CreateServerActionArgs<Info>
+  export type ClientActionArgs = T.CreateClientActionArgs<Info>
+
+  export type HydrateFallbackProps = T.CreateHydrateFallbackProps<Info>
+  export type ComponentProps = T.CreateComponentProps<Info>
+  export type ErrorBoundaryProps = T.CreateErrorBoundaryProps<Info>
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,6 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/home.tsx"),
+  route("/shows", "routes/shows.tsx"),
+] satisfies RouteConfig;

--- a/app/routes/shows.tsx
+++ b/app/routes/shows.tsx
@@ -1,0 +1,234 @@
+import { useLoaderData } from "react-router";
+
+import type { Route } from "./+types/shows";
+
+const CALENDAR_URL =
+  "https://calendar.google.com/calendar/ical/83c974b9154e94c01dad499b64e8a76f35ac37d9561fc8ac62c75caf0cd50661%40group.calendar.google.com/public/basic.ics";
+
+interface CalendarEvent {
+  id: string;
+  title: string;
+  description?: string;
+  start: Date;
+  end?: Date;
+  location?: string;
+  ticketUrl?: string;
+}
+
+export async function loader() {
+  const response = await fetch(CALENDAR_URL);
+
+  if (!response.ok) {
+    throw new Response("Unable to load shows", { status: response.status });
+  }
+
+  const ics = await response.text();
+  const events = parseIcs(ics)
+    .filter((event) => event.start.getTime() >= Date.now())
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  return events;
+}
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Shows | Mike Holm" },
+    {
+      name: "description",
+      content: "See upcoming shows pulled directly from Mike Holm's calendar.",
+    },
+  ];
+}
+
+export default function ShowsPage() {
+  const events = useLoaderData<typeof loader>();
+
+  return (
+    <main className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-12">
+        <header className="flex flex-col gap-3">
+          <p className="text-sm uppercase tracking-[0.3em] text-blue-600 dark:text-blue-300">
+            Shows
+          </p>
+          <h1 className="text-4xl font-semibold md:text-5xl">Catch Mike Live</h1>
+          <p className="text-lg text-slate-600 dark:text-slate-300">
+            Upcoming dates pulled directly from Mike's public Google Calendar.
+          </p>
+        </header>
+
+        {events.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-slate-300 bg-white/60 p-6 text-slate-500 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-300">
+            No shows are currently scheduled. Check back soon!
+          </p>
+        ) : (
+          <ul className="grid gap-4">
+            {events.map((event) => (
+              <li
+                key={event.id}
+                className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-800"
+              >
+                <div className="flex flex-col gap-3">
+                  <div className="flex flex-wrap items-center gap-3 text-sm uppercase tracking-wide text-blue-700 dark:text-blue-300">
+                    <time dateTime={event.start.toISOString()}>
+                      {formatDate(event.start)}
+                    </time>
+                    {event.end && (
+                      <span className="text-slate-400 dark:text-slate-500">
+                        &bull;
+                      </span>
+                    )}
+                    {event.end && (
+                      <time dateTime={event.end.toISOString()}>
+                        {formatTime(event.start)} - {formatTime(event.end)}
+                      </time>
+                    )}
+                  </div>
+                  <h2 className="text-2xl font-semibold">{event.title}</h2>
+                  {event.location && (
+                    <p className="text-sm text-slate-600 dark:text-slate-300">
+                      {event.location}
+                    </p>
+                  )}
+                  {event.description && (
+                    <p className="whitespace-pre-line text-slate-700 dark:text-slate-200">
+                      {event.description}
+                    </p>
+                  )}
+                  {event.ticketUrl && (
+                    <div>
+                      <a
+                        href={event.ticketUrl}
+                        className="inline-flex items-center gap-2 rounded-full bg-blue-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-blue-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+                        rel="noreferrer"
+                      >
+                        Buy Tickets
+                        <span aria-hidden>→</span>
+                      </a>
+                    </div>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function parseIcs(ics: string): CalendarEvent[] {
+  const lines = unfoldLines(ics.split(/\r?\n/));
+  const events: CalendarEvent[] = [];
+  let current: Partial<CalendarEvent> | null = null;
+
+  for (const line of lines) {
+    if (line === "BEGIN:VEVENT") {
+      current = {};
+      continue;
+    }
+
+    if (line === "END:VEVENT" && current) {
+      if (current.start && current.title) {
+        events.push({
+          id: `${current.start.getTime()}-${current.title}`,
+          title: current.title,
+          description: current.description,
+          start: current.start,
+          end: current.end,
+          location: current.location,
+          ticketUrl: current.ticketUrl,
+        });
+      }
+
+      current = null;
+      continue;
+    }
+
+    if (!current) continue;
+
+    const [rawKey, ...rest] = line.split(":");
+    const key = rawKey.split(";")[0];
+    const value = rest.join(":");
+
+    switch (key) {
+      case "SUMMARY":
+        current.title = value;
+        break;
+      case "DESCRIPTION": {
+        const description = value.replace(/\\n/g, "\n");
+        current.description = description;
+        const ticketLink = extractFirstLink(description);
+        if (ticketLink) current.ticketUrl = ticketLink;
+        break;
+      }
+      case "LOCATION":
+        current.location = value;
+        break;
+      case "DTSTART":
+      case "DTSTART;VALUE=DATE":
+      case "DTSTART;TZID=America/New_York":
+        current.start = parseDate(value);
+        break;
+      case "DTEND":
+      case "DTEND;VALUE=DATE":
+      case "DTEND;TZID=America/New_York":
+        current.end = parseDate(value);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return events;
+}
+
+function unfoldLines(lines: string[]): string[] {
+  const unfolded: string[] = [];
+
+  for (const line of lines) {
+    if (/^[ \t]/.test(line) && unfolded.length > 0) {
+      unfolded[unfolded.length - 1] += line.slice(1);
+    } else {
+      unfolded.push(line);
+    }
+  }
+
+  return unfolded;
+}
+
+function parseDate(value: string): Date {
+  // Handles formats like YYYYMMDD, YYYYMMDDTHHmmssZ, and YYYYMMDDTHHmmss
+  if (/^\d{8}$/.test(value)) {
+    return new Date(`${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}T00:00:00`);
+  }
+
+  if (/Z$/.test(value)) {
+    return new Date(value);
+  }
+
+  // Assume local time if no timezone suffix
+  const withSeparators = `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}T${value.slice(9, 11)}:${value.slice(11, 13)}:${value.slice(13, 15)}`;
+  return new Date(withSeparators);
+}
+
+function extractFirstLink(description?: string) {
+  if (!description) return undefined;
+  const match = description.match(/https?:\/\/\S+/i);
+  return match ? match[0].replace(/\\n/g, "") : undefined;
+}
+
+function formatDate(date: Date) {
+  return date.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatTime(date: Date) {
+  return date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/app/routes/shows.tsx
+++ b/app/routes/shows.tsx
@@ -2,7 +2,7 @@ import { useLoaderData } from "react-router";
 
 import type { Route } from "./+types/shows";
 
-const CALENDAR_URL =
+const DEFAULT_CALENDAR_URL =
   "https://calendar.google.com/calendar/ical/83c974b9154e94c01dad499b64e8a76f35ac37d9561fc8ac62c75caf0cd50661%40group.calendar.google.com/public/basic.ics";
 
 interface CalendarEvent {
@@ -16,7 +16,9 @@ interface CalendarEvent {
 }
 
 export async function loader() {
-  const response = await fetch(CALENDAR_URL);
+  const calendarUrl = getCalendarUrl();
+
+  const response = await fetch(calendarUrl);
 
   if (!response.ok) {
     throw new Response("Unable to load shows", { status: response.status });
@@ -209,6 +211,18 @@ function parseDate(value: string): Date {
   // Assume local time if no timezone suffix
   const withSeparators = `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}T${value.slice(9, 11)}:${value.slice(11, 13)}:${value.slice(13, 15)}`;
   return new Date(withSeparators);
+}
+
+function getCalendarUrl() {
+  if (typeof import.meta !== "undefined" && import.meta.env?.VITE_CALENDAR_URL) {
+    return import.meta.env.VITE_CALENDAR_URL;
+  }
+
+  if (typeof process !== "undefined" && process.env?.CALENDAR_URL) {
+    return process.env.CALENDAR_URL;
+  }
+
+  return DEFAULT_CALENDAR_URL;
 }
 
 function extractFirstLink(description?: string) {

--- a/app/routes/shows.tsx
+++ b/app/routes/shows.tsx
@@ -150,32 +150,32 @@ function parseIcs(ics: string): CalendarEvent[] {
     const key = rawKey.split(";")[0];
     const value = rest.join(":");
 
-    switch (key) {
-      case "SUMMARY":
-        current.title = value;
-        break;
-      case "DESCRIPTION": {
-        const description = value.replace(/\\n/g, "\n");
-        current.description = description;
-        const ticketLink = extractFirstLink(description);
-        if (ticketLink) current.ticketUrl = ticketLink;
-        break;
-      }
-      case "LOCATION":
-        current.location = value;
-        break;
-      case "DTSTART":
-      case "DTSTART;VALUE=DATE":
-      case "DTSTART;TZID=America/New_York":
-        current.start = parseDate(value);
-        break;
-      case "DTEND":
-      case "DTEND;VALUE=DATE":
-      case "DTEND;TZID=America/New_York":
-        current.end = parseDate(value);
-        break;
-      default:
-        break;
+    if (key === "SUMMARY") {
+      current.title = value;
+      continue;
+    }
+
+    if (key === "DESCRIPTION") {
+      const description = value.replace(/\\n/g, "\n");
+      current.description = description;
+      const ticketLink = extractFirstLink(description);
+      if (ticketLink) current.ticketUrl = ticketLink;
+      continue;
+    }
+
+    if (key === "LOCATION") {
+      current.location = value;
+      continue;
+    }
+
+    if (key.startsWith("DTSTART")) {
+      current.start = parseDate(value);
+      continue;
+    }
+
+    if (key.startsWith("DTEND")) {
+      current.end = parseDate(value);
+      continue;
     }
   }
 

--- a/app/welcome/welcome.tsx
+++ b/app/welcome/welcome.tsx
@@ -18,6 +18,12 @@ export function Welcome() {
               </li>
             ))}
           </ul>
+          <a
+            href="/shows"
+            className="inline-flex items-center rounded-full bg-blue-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-blue-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            See Upcoming Shows
+          </a>
           <Album {...head} />
         </header>
         <section className="grid grid-cols-2 gap-4">{rest.map(Album)}</section>

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    baseUrl: "http://localhost:5173",
+    supportFile: false,
+    specPattern: "cypress/e2e/**/*.cy.{ts,js,tsx,jsx}",
+  },
+});

--- a/cypress/e2e/shows.cy.ts
+++ b/cypress/e2e/shows.cy.ts
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+
+const CALENDAR_URL =
+  "https://calendar.google.com/calendar/ical/83c974b9154e94c01dad499b64e8a76f35ac37d9561fc8ac62c75caf0cd50661%40group.calendar.google.com/public/basic.ics";
+
+describe("Shows page", () => {
+  it("displays upcoming events from the calendar feed", () => {
+    cy.intercept("GET", CALENDAR_URL, {
+      fixture: "calendar.ics",
+      headers: { "content-type": "text/calendar" },
+    }).as("calendarFeed");
+
+    cy.visit("/shows");
+    cy.wait("@calendarFeed");
+
+    cy.get("main ul li").should("have.length", 2);
+    cy.contains("Winter Bash").should("exist");
+    cy.contains("New Year's Countdown").should("exist");
+    cy.contains("a", "Buy Tickets").should("have.length", 1);
+  });
+});

--- a/cypress/e2e/shows.cy.ts
+++ b/cypress/e2e/shows.cy.ts
@@ -1,17 +1,8 @@
 /// <reference types="cypress" />
 
-const CALENDAR_URL =
-  "https://calendar.google.com/calendar/ical/83c974b9154e94c01dad499b64e8a76f35ac37d9561fc8ac62c75caf0cd50661%40group.calendar.google.com/public/basic.ics";
-
 describe("Shows page", () => {
   it("displays upcoming events from the calendar feed", () => {
-    cy.intercept("GET", CALENDAR_URL, {
-      fixture: "calendar.ics",
-      headers: { "content-type": "text/calendar" },
-    }).as("calendarFeed");
-
     cy.visit("/shows");
-    cy.wait("@calendarFeed");
 
     cy.get("main ul li").should("have.length", 2);
     cy.contains("Winter Bash").should("exist");

--- a/cypress/fixtures/calendar.ics
+++ b/cypress/fixtures/calendar.ics
@@ -1,0 +1,20 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Mike Holm Music//Shows Test//EN
+BEGIN:VEVENT
+UID:event-1@example.com
+DTSTART;TZID=America/Chicago:20991224T190000
+DTEND;TZID=America/Chicago:20991224T210000
+SUMMARY:Winter Bash
+LOCATION:Chicago Theatre
+DESCRIPTION:Celebrate winter together\nhttps://tickets.example.com/winter
+END:VEVENT
+BEGIN:VEVENT
+UID:event-2@example.com
+DTSTART:20991231T230000Z
+DTEND:21000101T010000Z
+SUMMARY:New Year's Countdown
+LOCATION:Downtown Stage
+DESCRIPTION:Ring in the new year
+END:VEVENT
+END:VCALENDAR

--- a/public/test-calendar.ics
+++ b/public/test-calendar.ics
@@ -1,0 +1,20 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Mike Holm Music//Shows Test//EN
+BEGIN:VEVENT
+UID:event-1@example.com
+DTSTART;TZID=America/Chicago:20991224T190000
+DTEND;TZID=America/Chicago:20991224T210000
+SUMMARY:Winter Bash
+LOCATION:Chicago Theatre
+DESCRIPTION:Celebrate winter together\nhttps://tickets.example.com/winter
+END:VEVENT
+BEGIN:VEVENT
+UID:event-2@example.com
+DTSTART:20991231T230000Z
+DTEND:21000101T010000Z
+SUMMARY:New Year's Countdown
+LOCATION:Downtown Stage
+DESCRIPTION:Ring in the new year
+END:VEVENT
+END:VCALENDAR

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "**/.client/**/*",
     ".react-router/types/**/*"
   ],
+  "exclude": ["cypress/**/*", "cypress.config.*"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["node", "vite/client"],


### PR DESCRIPTION
## Summary
- add a /shows route that pulls upcoming events from the public Google Calendar feed
- parse ICS data to display dates, locations, descriptions, and ticket links
- link the homepage hero to the new shows page

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab561c7ac832e846750cd91b4c569)